### PR TITLE
Fixed bug on "order" and "order_inside" when concatenating where_* calls

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -1117,11 +1117,10 @@ class MY_Model extends CI_Model
      */
     protected function join_temporary_results($data)
     {
-        $order_by = array();
-        $order_inside_array = array();
-        //$order_inside = '';
         foreach($this->_requested as $requested_key => $request)
         {
+            $order_by = array();
+            $order_inside_array = array();
             $pivot_table = NULL;
             $relation = $this->_relationships[$request['request']];
             $this->load->model($relation['foreign_model'],$relation['foreign_model_name']);


### PR DESCRIPTION
The $order_by and $order_inside_array outside the loop didn't reset these values when concatenating [where_*] methods and made them stack for different queries, resulting in SQL errors.

Example error:
$catalog = $this->catalog_model
    ->with_segments('order_inside:code ASC')
    ->with_brand('order_inside:name ASC')
    ->get_all();

In this call, the "with_brand" call would run with both "order_inside:name ASC" and "order_inside:code ASC" params, the latter is stacked from the first call, which is unintended.